### PR TITLE
CMakeLists: use git log format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option (ENABLE_STATIC	"Build agasint static library." OFF)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wall -Wextra -Werror -Wstrict-prototypes -Wmissing-prototypes -std=c99 -O2")
 
-execute_process(COMMAND git --git-dir ${CMAKE_SOURCE_DIR}/.git log COMMAND head -1 COMMAND awk "{print $2}" COMMAND head -c 12 OUTPUT_VARIABLE GIT_SHA_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND git --git-dir ${CMAKE_SOURCE_DIR}/.git log --pretty=%H COMMAND head -1 -c 12 OUTPUT_VARIABLE GIT_SHA_VERSION)
 message(STATUS "Git version is ${GIT_SHA_VERSION}")
 
 # if neither static nor shared is enabled default to shared


### PR DESCRIPTION
Some user could have defined a format to display the git log in their `.gitconfig`. The command in the `CMakeLists.txt` shouldn't expect it the log format is the same everywhere for every user. To be sure, everybody will use the same format, just set it there to get the git SHA.