### PR TITLE
Fix tautological-compare error

### DIFF
--- a/gputop/top.c
+++ b/gputop/top.c
@@ -1956,8 +1956,8 @@ gtop_check_keyboard(struct perf_device *dev)
 
 #if defined HAVE_DDR_PERF && (defined __linux__ || defined __ANDROID__ || defined ANDROID)
 	/* disable reading DDR perf PMUs */
-	if ((curr_page != PAGE_SHOW_CLIENTS ||
-	     curr_page != PAGE_DDR_PERF) && perf_ddr_enabled) {
+	if (!(curr_page == PAGE_SHOW_CLIENTS ||
+	      curr_page == PAGE_DDR_PERF) && perf_ddr_enabled) {
 		gtop_disable_pmus();
 		perf_ddr_enabled = 0;
 	}


### PR DESCRIPTION
While building with clang 18, a warning informs about this error. The expression would always evaluate to true, otherwise. Assuming this is unintended and changed the expression, to what's likely intended.